### PR TITLE
feat: Update branding to Termi AI and fix GitHub repository references

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
-# Build Instructions for Cursovable
+# Build Instructions for Termi AI
 
-This document provides detailed instructions for building and distributing the Cursovable Electron application.
+This document provides detailed instructions for building and distributing the Termi AI Electron application.
 
 ## Prerequisites
 
@@ -131,7 +131,7 @@ module.exports = defineConfig(({ command, mode }) => ({
 {
   "build": {
     "appId": "com.cursovable.app",
-    "productName": "Cursovable",
+    "productName": "Termi AI",
     "files": ["electron/**", "renderer/dist/**", "package.json"],
     "directories": {
       "buildResources": "assets"
@@ -149,10 +149,10 @@ module.exports = defineConfig(({ command, mode }) => ({
 npm run dist
 
 # Output files in dist/:
-# - Cursovable-0.1.0-arm64.dmg
-# - Cursovable-0.1.0-arm64.zip
-# - Cursovable-0.1.0-x64.dmg
-# - Cursovable-0.1.0-x64.zip
+# - Termi-AI-0.1.0-arm64.dmg
+# - Termi-AI-0.1.0-arm64.zip
+# - Termi-AI-0.1.0-x64.dmg
+# - Termi-AI-0.1.0-x64.zip
 ```
 
 **Note**: macOS builds include both Intel (x64) and Apple Silicon (arm64) versions.
@@ -164,8 +164,8 @@ npm run dist
 npm run dist
 
 # Output files in dist/:
-# - Cursovable Setup 0.1.0.exe
-# - Cursovable-0.1.0-win.zip
+# - Termi-AI Setup 0.1.0.exe
+# - Termi-AI-0.1.0-win.zip
 ```
 
 ### Linux
@@ -175,9 +175,9 @@ npm run dist
 npm run dist
 
 # Output files in dist/:
-# - Cursovable-0.1.0-x86_64.AppImage
-# - Cursovable-0.1.0_amd64.deb
-# - Cursovable-0.1.0-x86_64.tar.gz
+# - Termi-AI-0.1.0-x86_64.AppImage
+# - Termi-AI-0.1.0_amd64.deb
+# - Termi-AI-0.1.0-x86_64.tar.gz
 ```
 
 ## Including snake-game.html
@@ -289,9 +289,9 @@ rm -rf renderer/dist/
 npm run pack
 
 # Test the app
-open dist/mac/Cursovable.app  # macOS
+open dist/mac/Termi-AI.app  # macOS
 # or
-start dist/win-unpacked/Cursovable.exe  # Windows
+start dist/win-unpacked/Termi-AI.exe  # Windows
 ```
 
 ### 2. Test Installer
@@ -301,7 +301,7 @@ start dist/win-unpacked/Cursovable.exe  # Windows
 npm run dist
 
 # Test the installer
-open dist/Cursovable-0.1.0-arm64.dmg  # macOS
+open dist/Termi-AI-0.1.0-arm64.dmg  # macOS
 ```
 
 ## Distribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Cursovable will be documented in this file.
+All notable changes to Termi AI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Cursovable
+# Contributing to Termi AI
 
-Thank you for your interest in contributing to Cursovable! This document provides guidelines and information for contributors.
+Thank you for your interest in contributing to Termi AI! This document provides guidelines and information for contributors.
 
 ## 🤝 How to Contribute
 
@@ -210,4 +210,4 @@ Contributors will be recognized in:
 - Release notes
 - Contributor hall of fame (when implemented)
 
-Thank you for contributing to Cursovable! 🚀
+Thank you for contributing to Termi AI! 🚀

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Cursovable
+Copyright (c) 2024 Termi AI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MAC-INSTALL.md
+++ b/MAC-INSTALL.md
@@ -1,6 +1,6 @@
-# Mac Installation Guide for Cursovable
+# Mac Installation Guide for Termi AI
 
-This guide provides step-by-step instructions for installing and running Cursovable on macOS, specifically addressing the challenges of running unsigned applications.
+This guide provides step-by-step instructions for installing and running Termi AI on macOS, specifically addressing the challenges of running unsigned applications.
 
 ## Quick Start
 
@@ -14,8 +14,8 @@ This guide provides step-by-step instructions for installing and running Cursova
 ### Step 1: Download and Extract
 
 - Download the latest `.dmg` file for your Mac's architecture:
-  - **Apple Silicon (M1/M2/M3)**: `Cursovable-0.1.0-arm64.dmg`
-  - **Intel Macs**: `Cursovable-0.1.0-x64.dmg`
+  - **Apple Silicon (M1/M2/M3)**: `Termi-AI-0.1.0-arm64.dmg`
+  - **Intel Macs**: `Termi-AI-0.1.0-x64.dmg`
 - Double-click the `.dmg` file to mount it
 - Drag the app to your Applications folder
 
@@ -23,7 +23,7 @@ This guide provides step-by-step instructions for installing and running Cursova
 
 When you first try to launch the app, macOS will block it with a security warning:
 
-1. **Right-click** (or Control+click) on the Cursovable app
+1. **Right-click** (or Control+click) on the Termi AI app
 2. Select **"Open"** from the context menu
 3. Click **"Open"** in the security dialog that appears
 4. The app will now launch successfully
@@ -34,7 +34,7 @@ When you first try to launch the app, macOS will block it with a security warnin
 
 1. Go to **System Preferences** → **Security & Privacy**
 2. Click the **"General"** tab
-3. Look for a message about "Cursovable was blocked from opening"
+3. Look for a message about "Termi AI was blocked from opening"
 4. Click **"Open Anyway"** to allow the app to run
 5. Try launching the app again
 
@@ -42,10 +42,10 @@ When you first try to launch the app, macOS will block it with a security warnin
 
 ```bash
 # Remove the quarantine attribute (use with caution)
-xattr -rd com.apple.quarantine /Applications/Cursovable.app
+xattr -rd com.apple.quarantine /Applications/Termi-AI.app
 
 # Then launch normally
-open /Applications/Cursovable.app
+open /Applications/Termi-AI.app
 ```
 
 #### Method C: Developer Mode (macOS 13+)
@@ -60,7 +60,7 @@ open /Applications/Cursovable.app
 ```bash
 # Navigate to the app and run directly
 cd /Applications
-./Cursovable.app/Contents/MacOS/Cursovable
+./Termi-AI.app/Contents/MacOS/Termi-AI
 ```
 
 ## Troubleshooting
@@ -71,10 +71,10 @@ If you see "App is damaged and can't be opened":
 
 ```bash
 # Remove quarantine attribute
-xattr -rd com.apple.quarantine /Applications/Cursovable.app
+xattr -rd com.apple.quarantine /Applications/Termi-AI.app
 
 # Or check what attributes are set
-xattr -l /Applications/Cursovable.app
+xattr -l /Applications/Termi-AI.app
 ```
 
 ### "Unidentified Developer" Warning
@@ -91,10 +91,10 @@ This is normal for unsigned apps. Use the right-click "Open" method described ab
 
 ```bash
 # Check file permissions
-ls -la /Applications/Cursovable.app
+ls -la /Applications/Termi-AI.app
 
 # Fix permissions if needed
-chmod +x /Applications/Cursovable.app/Contents/MacOS/Cursovable
+chmod +x /Applications/Termi-AI.app/Contents/MacOS/Termi-AI
 ```
 
 ## Security Considerations
@@ -133,7 +133,7 @@ Currently, the app doesn't support automatic updates. To update:
 
 ```bash
 # Remove old version
-rm -rf /Applications/Cursovable.app
+rm -rf /Applications/Termi-AI.app
 
 # Install new version
 # (Follow installation steps above)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚀 Cursovable
+# 🚀 Termi AI
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey.svg)](https://github.com/BaronJensen/cursovable)
@@ -7,9 +7,9 @@
 
 > **Your AI-powered development companion** - A desktop app that combines live project previews with intelligent AI assistance using Cursor Agent.
 
-## ✨ What is Cursovable?
+## ✨ What is Termi AI?
 
-Cursovable is an Electron-based desktop application that revolutionizes your development workflow by providing:
+Termi AI is an Electron-based desktop application that revolutionizes your development workflow by providing:
 
 - **🖥️ Live Project Preview**: Automatically detect and embed your React/Vite projects in real-time
 - **🤖 AI Development Assistant**: Integrated chat interface powered by Cursor Agent
@@ -76,7 +76,7 @@ npm run dev
 
 ## 🚀 Quick Start
 
-1. **Launch the App**: Start Cursovable from your applications menu
+1. **Launch the App**: Start Termi AI from your applications menu
 2. **Choose Your Project**: Click "Choose folder" and select your React/Vite project
 3. **Select Package Manager**: Choose between yarn, npm, or pnpm
 4. **Run Development Server**: Click "Run Vite" to start your project
@@ -109,7 +109,7 @@ npm run pack
 ### Project Structure
 
 ```
-cursovable/
+termi-ai/
 ├── electron/           # Electron main process
 │   ├── main.cjs       # Main entry point
 │   ├── preload.cjs    # Preload script for IPC
@@ -125,7 +125,7 @@ cursovable/
 
 ### Environment Variables
 
-- `CURSOVABLE_DEBUG_MODE=1`: Enable debug mode for development
+- `TERMI_AI_DEBUG_MODE=1`: Enable debug mode for development
 - `OPENAI_API_KEY`: Your OpenAI API key (optional, passed to cursor-agent)
 
 ### Build Configuration
@@ -214,6 +214,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-**Made with ❤️ by the Cursovable community**
+**Made with ❤️ by the Termi AI community**
 
 If you find this project helpful, please consider giving it a ⭐ star on GitHub!

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Cursovable GitHub Pages
+# Termi AI GitHub Pages
 
-This directory contains the source files for the Cursovable GitHub Pages website.
+This directory contains the source files for the Termi AI GitHub Pages website.
 
 ## 🚀 Quick Start
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,22 +1,22 @@
-# Cursovable GitHub Pages Configuration
+# Termi AI GitHub Pages Configuration
 # This file configures Jekyll for GitHub Pages
 
 # Site settings
-title: Cursovable
+title: Termi AI
 description: Your AI-powered development companion - A desktop app that combines live project previews with intelligent AI assistance using Cursor Agent.
-url: "https://yourusername.github.io"
+url: "https://baronjensen.github.io"
 baseurl: "/cursovable"
 
 # Author information
 author:
-  name: Cursovable Team
-  email: hello@cursovable.com
+  name: Termi AI Team
+  email: hello@termi-ai.com
   bio: Building the future of AI-powered development
   location: Worldwide
   links:
     - label: GitHub
       icon: fab fa-github
-      url: https://github.com/yourusername/cursovable
+      url: https://github.com/BaronJensen/cursovable
 
 # Build settings
 markdown: kramdown
@@ -47,15 +47,15 @@ exclude:
 # Social media
 social:
   - name: GitHub
-    url: https://github.com/yourusername/cursovable
+    url: https://github.com/BaronJensen/cursovable
     icon: fab fa-github
 
 # SEO settings
 seo:
-  title: Cursovable - Your AI-Powered Development Companion
+  title: Termi AI - Your AI-Powered Development Companion
   description: Combine live project previews with intelligent AI assistance using Cursor Agent. Available for macOS, Windows, and Linux.
   keywords:
-    - cursovable
+    - termi ai
     - electron
     - react
     - vite
@@ -68,10 +68,10 @@ seo:
   type: website
   twitter:
     card: summary_large_image
-    creator: "@cursovable"
+    creator: "@termi-ai"
   og:
     type: website
-    site_name: Cursovable
+    site_name: Termi AI
 
 # Analytics (uncomment and configure as needed)
 # google_analytics: UA-XXXXXXXXX-X
@@ -79,7 +79,7 @@ seo:
 
 # Comments (uncomment and configure as needed)
 # disqus:
-#   shortname: cursovable
+#   shortname: termi-ai
 
 # Sitemap
 sitemap:
@@ -96,7 +96,7 @@ redirect_from:
 # Head and footer includes removed for GitHub Pages compatibility
 
 # Custom variables
-cursovable:
+termi-ai:
   version: "0.1.0"
   latest_release: "2024-12-19"
   platforms:

--- a/docs/debug-mode.md
+++ b/docs/debug-mode.md
@@ -1,6 +1,6 @@
-# Debug Mode for Cursovable
+# Debug Mode for Termi AI
 
-The debug mode allows you to test the Cursovable application without calling the real `cursor-agent` CLI. Instead, it uses a mock data generator that simulates realistic responses.
+The debug mode allows you to test the Termi AI application without calling the real `cursor-agent` CLI. Instead, it uses a mock data generator that simulates realistic responses.
 
 ## Features
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,23 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cursovable - Your AI-Powered Development Companion</title>
-    <meta name="description" content="Cursovable complements AI platforms like Lovable, V0, Gemini, and ChatGPT. Import any project and continue development locally with cursor-cli integration.">
-    <meta name="keywords" content="cursovable, electron, react, vite, ai, development, cursor agent, desktop app, project import, local development, lovable complement, v0 complement, gemini, chatgpt">
+    <title>Termi AI - Your AI-Powered Development Companion</title>
+    <meta name="description" content="Termi AI complements AI platforms like Lovable, V0, Gemini, and ChatGPT. Import any project and continue development locally with cursor-cli integration.">
+    <meta name="keywords" content="termi ai, electron, react, vite, ai, development, cursor agent, desktop app, project import, local development, lovable complement, v0 complement, gemini, chatgpt">
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://jensbaronville.github.io/cursovable/">
-    <meta property="og:title" content="Cursovable - Import Any AI Project, Build Locally">
+    <meta property="og:url" content="https://baronjensen.github.io/cursovable/">
+    <meta property="og:title" content="Termi AI - Import Any AI Project, Build Locally">
     <meta property="og:description" content="Import projects from any AI platform - Lovable, V0, Gemini, ChatGPT, or simple HTML. Continue development locally with cursor-cli integration.">
-    <meta property="og:image" content="https://jensbaronville.github.io/cursovable/assets/icon_square.png">
+    <meta property="og:image" content="https://baronjensen.github.io/cursovable/assets/icon_square.png">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://jensbaronville.github.io/cursovable/">
-    <meta property="twitter:title" content="Cursovable - Import Any AI Project, Build Locally">
+    <meta property="twitter:url" content="https://baronjensen.github.io/cursovable/">
+    <meta property="twitter:title" content="Termi AI - Import Any AI Project, Build Locally">
     <meta property="twitter:description" content="Import projects from any AI platform - Lovable, V0, Gemini, ChatGPT, or simple HTML. Continue development locally with cursor-cli integration.">
-    <meta property="twitter:image" content="https://jensbaronville.github.io/cursovable/assets/icon_square.png">
+    <meta property="twitter:image" content="https://baronjensen.github.io/cursovable/assets/icon_square.png">
 
     <link rel="icon" type="image/png" href="assets/icon_square.png">
     <link rel="stylesheet" href="styles.css">
@@ -37,14 +37,14 @@
     <nav class="navbar">
         <div class="nav-container">
             <div class="nav-logo">
-                <img src="assets/icon_square.png" alt="Cursovable Logo" class="nav-logo-img">
-                <span>Cursovable</span>
+                <img src="assets/icon_square.png" alt="Termi AI Logo" class="nav-logo-img">
+                <span>Termi AI</span>
             </div>
             <div class="nav-links">
                 <a href="#features">Features</a>
                 <a href="#download">Download</a>
                 <a href="#docs">Documentation</a>
-                <a href="https://github.com/jensbaronville/cursovable" target="_blank" rel="noopener">
+                 <a href="https://github.com/BaronJensen/cursovable" target="_blank" rel="noopener">
                     <i class="fab fa-github"></i>
                     GitHub
                 </a>
@@ -62,14 +62,14 @@
         <div class="hero-container">
             <div class="hero-content">
                 <div class="hero-logo">
-                    <img src="assets/icon_square.png" alt="Cursovable Logo" class="hero-logo-img">
+                    <img src="assets/icon_square.png" alt="Termi AI Logo" class="hero-logo-img">
                 </div>
                 <h1 class="hero-title">
                     Import Any AI Project,
                     <span class="gradient-text">Build Locally</span>
                 </h1>
                 <p class="hero-description">
-                    Start your project anywhere - Lovable, V0, Gemini, ChatGPT, or simple HTML. Cursovable lets you import any project folder and continue development locally with cursor-cli integration. 
+                    Start your project anywhere - Lovable, V0, Gemini, ChatGPT, or simple HTML. Termi AI lets you import any project folder and continue development locally with cursor-cli integration. 
                     <strong>Import your project and we'll get it running immediately.</strong>
                 </p>
                 <div class="hero-buttons">
@@ -77,7 +77,7 @@
                         <i class="fas fa-clock"></i>
                         Coming Soon
                     </a>
-                    <a href="https://github.com/jensbaronville/cursovable" target="_blank" rel="noopener" class="btn btn-secondary">
+                     <a href="https://github.com/BaronJensen/cursovable" target="_blank" rel="noopener" class="btn btn-secondary">
                         <i class="fab fa-github"></i>
                         View on GitHub
                     </a>
@@ -144,7 +144,7 @@
     <section id="features" class="features">
         <div class="container">
             <div class="section-header">
-                <h2>Why Choose Cursovable?</h2>
+                <h2>Why Choose Termi AI?</h2>
                 <p>Built for developers who want to continue projects locally with full control over their development environment</p>
             </div>
             <div class="features-grid">
@@ -221,7 +221,7 @@
                 </div>
                 <div class="comparison-card cursovable">
                     <div class="comparison-header">
-                        <h3>AI Platform + Cursovable</h3>
+                        <h3>AI Platform + Termi AI</h3>
                         <div class="cost-badge affordable">Best of Both</div>
                     </div>
                     <ul class="comparison-list">
@@ -232,7 +232,7 @@
                         <li><i class="fas fa-check"></i> No usage limits locally</li>
                     </ul>
                     <div class="estimated-cost">
-                        <span class="cost-label">Cursovable Cost:</span>
+                        <span class="cost-label">Termi AI Cost:</span>
                         <span class="cost-amount">Free</span>
                     </div>
                 </div>
@@ -259,7 +259,7 @@
                     <div class="step-number">2</div>
                     <div class="step-content">
                         <h3>Import Project Folder</h3>
-                        <p>Simply import your project folder into Cursovable - we handle the setup and provide live preview</p>
+                        <p>Simply import your project folder into Termi AI - we handle the setup and provide live preview</p>
                     </div>
                 </div>
                 <div class="step">
@@ -277,7 +277,7 @@
     <section id="download" class="download">
         <div class="container">
             <div class="section-header">
-                <h2>Download Cursovable</h2>
+                <h2>Download Termi AI</h2>
                 <p>Coming soon to all major platforms</p>
             </div>
             <div class="download-grid">
@@ -329,7 +329,7 @@
             </div>
             <div class="build-from-source">
                 <h3>🚀 Try It Now - Run from Source</h3>
-                <p>While we prepare the official releases, you can run Cursovable from source! Check out our <a href="https://github.com/jensbaronville/cursovable#quick-start" target="_blank" rel="noopener">installation guide</a> to get started immediately. Simply import your project and it runs right away.</p>
+                 <p>While we prepare the official releases, you can run Termi AI from source! Check out our <a href="https://github.com/BaronJensen/cursovable#quick-start" target="_blank" rel="noopener">installation guide</a> to get started immediately. Simply import your project and it runs right away.</p>
                 <div class="build-steps">
                     <div class="build-step">
                         <i class="fas fa-terminal"></i>
@@ -361,8 +361,8 @@
                         <i class="fas fa-book"></i>
                     </div>
                     <h3>Getting Started</h3>
-                    <p>Quick setup guide and first steps with Cursovable</p>
-                    <a href="https://github.com/jensbaronville/cursovable#quick-start" target="_blank" rel="noopener" class="doc-link">
+                    <p>Quick setup guide and first steps with Termi AI</p>
+                     <a href="https://github.com/BaronJensen/cursovable#quick-start" target="_blank" rel="noopener" class="doc-link">
                         Read Guide <i class="fas fa-arrow-right"></i>
                     </a>
                 </div>
@@ -372,7 +372,7 @@
                     </div>
                     <h3>Contributing</h3>
                     <p>Learn how to contribute to the project</p>
-                    <a href="https://github.com/jensbaronville/cursovable/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener" class="doc-link">
+                     <a href="https://github.com/BaronJensen/cursovable/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener" class="doc-link">
                         View Guidelines <i class="fas fa-arrow-right"></i>
                     </a>
                 </div>
@@ -382,7 +382,7 @@
                     </div>
                     <h3>Troubleshooting</h3>
                     <p>Common issues and their solutions</p>
-                    <a href="https://github.com/jensbaronville/cursovable#troubleshooting" target="_blank" rel="noopener" class="doc-link">
+                     <a href="https://github.com/BaronJensen/cursovable#troubleshooting" target="_blank" rel="noopener" class="doc-link">
                         View Solutions <i class="fas fa-arrow-right"></i>
                     </a>
                 </div>
@@ -392,7 +392,7 @@
                     </div>
                     <h3>FAQ</h3>
                     <p>Frequently asked questions and answers</p>
-                    <a href="https://github.com/jensbaronville/cursovable/discussions" target="_blank" rel="noopener" class="doc-link">
+                     <a href="https://github.com/BaronJensen/cursovable/discussions" target="_blank" rel="noopener" class="doc-link">
                         Ask Questions <i class="fas fa-arrow-right"></i>
                     </a>
                 </div>
@@ -407,11 +407,11 @@
                 <h2>Ready to Build Locally?</h2>
                 <p>Join developers who complement their AI platform workflow with local development. Start anywhere, import everything, build with full control.</p>
                 <div class="cta-buttons">
-                    <a href="https://github.com/jensbaronville/cursovable" target="_blank" rel="noopener" class="btn btn-primary btn-large">
+                     <a href="https://github.com/BaronJensen/cursovable" target="_blank" rel="noopener" class="btn btn-primary btn-large">
                         <i class="fab fa-github"></i>
                         Star on GitHub
                     </a>
-                    <a href="https://github.com/jensbaronville/cursovable" target="_blank" rel="noopener" class="btn btn-secondary btn-large">
+                    <a href="https://github.com/BaronJensen/cursovable" target="_blank" rel="noopener" class="btn btn-secondary btn-large">
                         <i class="fas fa-code"></i>
                         View Source Code
                     </a>
@@ -426,18 +426,18 @@
             <div class="footer-content">
                 <div class="footer-section">
                     <div class="footer-logo">
-                        <img src="assets/icon_square.png" alt="Cursovable Logo" class="footer-logo-img">
-                        <span>Cursovable</span>
+                        <img src="assets/icon_square.png" alt="Termi AI Logo" class="footer-logo-img">
+                        <span>Termi AI</span>
                     </div>
                     <p>Your AI-powered development companion</p>
                     <div class="social-links">
-                        <a href="https://github.com/jensbaronville/cursovable" target="_blank" rel="noopener" aria-label="GitHub">
+                         <a href="https://github.com/BaronJensen/cursovable" target="_blank" rel="noopener" aria-label="GitHub">
                             <i class="fab fa-github"></i>
                         </a>
-                        <a href="https://github.com/jensbaronville/cursovable/discussions" target="_blank" rel="noopener" aria-label="Discussions">
+                        <a href="https://github.com/BaronJensen/cursovable/discussions" target="_blank" rel="noopener" aria-label="Discussions">
                             <i class="fas fa-comments"></i>
                         </a>
-                        <a href="https://github.com/jensbaronville/cursovable/issues" target="_blank" rel="noopener" aria-label="Issues">
+                        <a href="https://github.com/BaronJensen/cursovable/issues" target="_blank" rel="noopener" aria-label="Issues">
                             <i class="fas fa-bug"></i>
                         </a>
                     </div>
@@ -445,10 +445,10 @@
                 <div class="footer-section">
                     <h4>Project</h4>
                     <ul>
-                        <li><a href="https://github.com/jensbaronville/cursovable/releases" target="_blank" rel="noopener">Releases</a></li>
-                        <li><a href="https://github.com/jensbaronville/cursovable/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
-                        <li><a href="https://github.com/jensbaronville/cursovable/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
-                        <li><a href="https://github.com/jensbaronville/cursovable/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a></li>
+                        <li><a href="https://github.com/BaronJensen/cursovable/releases" target="_blank" rel="noopener">Releases</a></li>
+                        <li><a href="https://github.com/BaronJensen/cursovable/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
+                        <li><a href="https://github.com/BaronJensen/cursovable/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
+                        <li><a href="https://github.com/BaronJensen/cursovable/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
@@ -463,14 +463,14 @@
                 <div class="footer-section">
                     <h4>Legal</h4>
                     <ul>
-                        <li><a href="https://github.com/jensbaronville/cursovable/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
-                        <li><a href="https://github.com/jensbaronville/cursovable/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a></li>
-                        <li><a href="https://github.com/jensbaronville/cursovable/security" target="_blank" rel="noopener">Security</a></li>
+                        <li><a href="https://github.com/BaronJensen/cursovable/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
+                        <li><a href="https://github.com/BaronJensen/cursovable/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a></li>
+                        <li><a href="https://github.com/BaronJensen/cursovable/security" target="_blank" rel="noopener">Security</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 Cursovable. Made with ❤️ by the open source community.</p>
+                <p>&copy; 2024 Termi AI. Made with ❤️ by the open source community.</p>
             </div>
         </div>
     </footer>

--- a/docs/multi-session-implementation.md
+++ b/docs/multi-session-implementation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the implementation of multi-session support in Cursovable, allowing multiple chat sessions to run concurrently with unique terminals for better debugging and workflow management.
+This document describes the implementation of multi-session support in Termi AI, allowing multiple chat sessions to run concurrently with unique terminals for better debugging and workflow management.
 
 ## Key Features
 

--- a/docs/multi-session-ui-updates.md
+++ b/docs/multi-session-ui-updates.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the updates made to the Cursovable UI to support multiple concurrent cursor-agent terminals, allowing users to run multiple chat sessions simultaneously and navigate between them without killing active processes.
+This document describes the updates made to the Termi AI UI to support multiple concurrent cursor-agent terminals, allowing users to run multiple chat sessions simultaneously and navigate between them without killing active processes.
 
 ## Key Changes Made
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,4 +1,4 @@
-// Cursovable GitHub Pages - Interactive Features
+// Termi AI GitHub Pages - Interactive Features
 document.addEventListener('DOMContentLoaded', function() {
     
     // Mobile Navigation Toggle
@@ -401,7 +401,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 // Export functions for potential external use
-window.CursovableSite = {
+window.TermiAISite = {
     trackEvent,
     updateGitHubStats,
     performSearch

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -525,8 +525,8 @@ function createMenu() {
           click: () => {
             dialog.showMessageBox(win, {
               type: 'info',
-              title: 'About Cursovable',
-              message: 'Cursovable - AI-powered development environment',
+              title: 'About Termi AI',
+              message: 'Termi AI - AI-powered development environment',
               detail: 'Version 1.0.0\nA modern development environment with AI assistance.'
             });
           }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cursovable",
+  "name": "termi-ai",
   "version": "0.1.1",
   "private": true,
   "main": "electron/main.cjs",
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/BaronJensen/cursovable",
   "scripts": {
     "dev": "concurrently -k \"npm:renderer\" \"npm:electron\"",
-    "dev:debug": "cross-env CURSOVABLE_DEBUG_MODE=1 concurrently -k \"npm:renderer\" \"npm:electron\"",
+    "dev:debug": "cross-env TERMI_AI_DEBUG_MODE=1 concurrently -k \"npm:renderer\" \"npm:electron\"",
     "dev:hot": "concurrently -k \"npm:renderer\" \"npm:electron:hot\"",
     "renderer": "vite --config renderer/vite.config.cjs",
     "electron": "wait-on http://localhost:5174 && cross-env RENDERER_URL=http://localhost:5174 electron .",
@@ -43,8 +43,8 @@
     "wait-on": "^7.2.0"
   },
   "build": {
-    "appId": "com.cursovable.app",
-    "productName": "Cursovable",
+    "appId": "com.termi-ai.app",
+    "productName": "Termi AI",
     "files": [
       "electron/**",
       "renderer/dist/**",

--- a/renderer/src/components/Chat/hooks/README.md
+++ b/renderer/src/components/Chat/hooks/README.md
@@ -1,6 +1,6 @@
 # Chat Hooks Documentation
 
-This directory contains React hooks that manage the chat functionality, session management, and terminal communication for the Cursovable application.
+This directory contains React hooks that manage the chat functionality, session management, and terminal communication for the Termi AI application.
 
 ## Hook Architecture
 
@@ -21,6 +21,7 @@ SessionProvider (Context Provider)
 The main hook that orchestrates all session-related functionality.
 
 **Responsibilities:**
+
 - Session state management (create, load, delete, switch)
 - Message storage and retrieval
 - Tool call state management
@@ -28,6 +29,7 @@ The main hook that orchestrates all session-related functionality.
 - Cursor command execution
 
 **Key Functions:**
+
 - `createNewSession()` - Create a new chat session
 - `loadSession(sessionId)` - Switch to an existing session
 - `deleteSession(sessionId)` - Remove a session
@@ -35,6 +37,7 @@ The main hook that orchestrates all session-related functionality.
 - `updateSessionWithCursorId(sessionId, cursorSessionId)` - Link internal session to cursor session
 
 **State:**
+
 - `sessions` - Array of all sessions
 - `currentSessionId` - Currently active session
 - `busyBySession` - Map of session busy states
@@ -46,11 +49,13 @@ The main hook that orchestrates all session-related functionality.
 Specialized hook for processing different types of messages from cursor sessions.
 
 **Responsibilities:**
+
 - Parse and handle JSON log messages
 - Create appropriate message objects for different types
 - Route messages to the correct session
 
 **Supported Message Types:**
+
 - `session_start` - Session initialization
 - `assistant` - AI assistant responses
 - `result` - Command execution results
@@ -65,6 +70,7 @@ Specialized hook for processing different types of messages from cursor sessions
 - `error` - Error messages
 
 **Key Functions:**
+
 - `handleParsedMessage(parsed, sessionId)` - Main message processor
 - Individual handlers for each message type
 
@@ -73,12 +79,14 @@ Specialized hook for processing different types of messages from cursor sessions
 Manages terminal communication and cursor session mapping.
 
 **Responsibilities:**
+
 - Set up centralized log router
 - Route logs to appropriate session handlers
 - Provide terminal status information
 - Manage cursor session ID mapping
 
 **Key Functions:**
+
 - `setupLogRouter()` - Initialize the log routing system
 - `handleCursorLog(payload)` - Process incoming cursor logs
 - `getSessionTerminalStatus(sessionId)` - Get terminal status for a session
@@ -86,6 +94,7 @@ Manages terminal communication and cursor session mapping.
 - `cleanupLogRouter()` - Clean up router resources
 
 **State:**
+
 - `logRouter` - Reference to the active log router
 - Session status mapping functions
 
@@ -94,6 +103,7 @@ Manages terminal communication and cursor session mapping.
 Handles chat input and message sending.
 
 **Responsibilities:**
+
 - Manage chat input state
 - Handle message submission
 - Integrate with session manager for sending
@@ -103,22 +113,17 @@ Handles chat input and message sending.
 ### Basic Session Management
 
 ```jsx
-import { useSession } from '../providers/SessionProvider';
+import { useSession } from "../providers/SessionProvider";
 
 function ChatComponent() {
-  const { 
-    sessions, 
-    currentSessionId, 
-    createNewSession, 
-    send 
-  } = useSession();
+  const { sessions, currentSessionId, createNewSession, send } = useSession();
 
   const handleNewSession = () => {
     createNewSession();
   };
 
   const handleSend = (text) => {
-    const currentSession = sessions.find(s => s.id === currentSessionId);
+    const currentSession = sessions.find((s) => s.id === currentSessionId);
     send(text, currentSession);
   };
 
@@ -134,13 +139,11 @@ function ChatComponent() {
 ### Terminal Status Monitoring
 
 ```jsx
-import { useSession } from '../providers/SessionProvider';
+import { useSession } from "../providers/SessionProvider";
 
 function TerminalStatus() {
-  const { 
-    getCurrentTerminalSession,
-    getAllSessionsTerminalStatus 
-  } = useSession();
+  const { getCurrentTerminalSession, getAllSessionsTerminalStatus } =
+    useSession();
 
   const currentTerminal = getCurrentTerminalSession();
   const allStatuses = getAllSessionsTerminalStatus();
@@ -149,9 +152,9 @@ function TerminalStatus() {
     <div>
       <h3>Current Terminal: {currentTerminal?.name}</h3>
       <div>
-        {allStatuses.map(status => (
+        {allStatuses.map((status) => (
           <div key={status.id}>
-            {status.name} - {status.runningTerminal ? 'Running' : 'Idle'}
+            {status.name} - {status.runningTerminal ? "Running" : "Idle"}
           </div>
         ))}
       </div>
@@ -163,20 +166,19 @@ function TerminalStatus() {
 ### Message Processing
 
 ```jsx
-import { useMessageHandler } from './hooks/useMessageHandler';
+import { useMessageHandler } from "./hooks/useMessageHandler";
 
 function MessageProcessor({ addMessageToSession, updateSessionWithCursorId }) {
-  const messageHandler = useMessageHandler(addMessageToSession, updateSessionWithCursorId);
+  const messageHandler = useMessageHandler(
+    addMessageToSession,
+    updateSessionWithCursorId
+  );
 
   const processMessage = (parsedMessage, sessionId) => {
     messageHandler.handleParsedMessage(parsedMessage, sessionId);
   };
 
-  return (
-    <div>
-      {/* Message processing UI */}
-    </div>
-  );
+  return <div>{/* Message processing UI */}</div>;
 }
 ```
 
@@ -199,6 +201,7 @@ function MessageProcessor({ addMessageToSession, updateSessionWithCursorId }) {
 ## Error Handling
 
 All hooks include comprehensive error handling:
+
 - Try-catch blocks around critical operations
 - Console logging for debugging
 - Graceful fallbacks for missing data

--- a/renderer/src/components/Hero/Hero.jsx
+++ b/renderer/src/components/Hero/Hero.jsx
@@ -5,7 +5,7 @@ import Select from '../../ui/Select';
 function Hero({ idea, setIdea, template, setTemplate, onCreateClick }) {
   return (
     <div className="ds-hero">
-      <div className="ds-hero-title">Build <span className="accent">Cursovable</span> projects with AI</div>
+      <div className="ds-hero-title">Build <span className="accent">Termi AI</span> projects with AI</div>
       <div className="ds-hero-subtitle">Create apps locally with AI</div>
       <div className="ds-hero-bar">
         <textarea


### PR DESCRIPTION
- Rename project from Cursovable to Termi AI throughout the site
- Update all GitHub repository links to use correct username BaronJensen
- Fix GitHub Pages URLs to point to baronjensen.github.io/cursovable
- Update meta tags, Open Graph, and Twitter Card URLs
- Revise value proposition to focus on project import rather than cost avoidance
- Update features to emphasize universal project support (Vite, Next.js, HTML)
- Modify workflow to highlight "start anywhere, import anything, continue locally"
- Update comparison section to show AI Platform + Termi AI as complementary
- Fix navbar styling and add app logo throughout the site
- Update Jekyll configuration with correct repository references
- Ensure all documentation and social links point to BaronJensen/cursovable

This aligns the site with the actual GitHub repository and presents Termi AI as a complementary tool that works with existing AI platforms rather than a replacement, focusing on seamless project import and local development.