### PR TITLE
feat: Update Electron app UI branding from cursovable to Termi AI

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -474,8 +474,8 @@ function createMenu() {
             try {
               if (lastViteFolder) {
                 await win.webContents.executeJavaScript(`
-                  if (window.cursovable && window.cursovable.startVite) {
-                    window.cursovable.startVite({ folderPath: '${lastViteFolder}', manager: 'yarn' });
+                  if (window.termiAI && window.termiAI.startVite) {
+                    window.termiAI.startVite({ folderPath: '${lastViteFolder}', manager: 'yarn' });
                   }
                 `);
               }
@@ -491,8 +491,8 @@ function createMenu() {
           click: async () => {
             try {
               await win.webContents.executeJavaScript(`
-                if (window.cursovable && window.cursovable.stopVite) {
-                  window.cursovable.stopVite();
+                if (window.termiAI && window.termiAI.stopVite) {
+                  window.termiAI.stopVite();
                 }
               `);
             } catch (err) {
@@ -506,8 +506,8 @@ function createMenu() {
           click: async () => {
             try {
               await win.webContents.executeJavaScript(`
-                if (window.cursovable && window.cursovable.forceTerminalCleanup) {
-                  window.cursovable.forceTerminalCleanup();
+                if (window.termiAI && window.termiAI.forceTerminalCleanup) {
+                  window.termiAI.forceTerminalCleanup();
                 }
               `);
             } catch (err) {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,7 +1,7 @@
 
 const { contextBridge, ipcRenderer } = require('electron');
 
-contextBridge.exposeInMainWorld('cursovable', {
+contextBridge.exposeInMainWorld('termiAI', {
   selectFolder: () => ipcRenderer.invoke('select-folder'),
   folderSelected: (cb) => {
     const listener = (_e, folderPath) => cb(folderPath);

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>cursovable</title>
+    <title>Termi AI</title>
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' http: https: data: blob: filesystem:; img-src 'self' data: blob: *; media-src 'self' data: blob: *; style-src 'self' 'unsafe-inline' https:; font-src 'self' data: https:; connect-src * data: blob:; frame-src *; child-src *; frame-ancestors *;" />
     <style>
       html, body, #root { height: 100%; margin: 0; }

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -27,7 +27,7 @@ function LegacyApp() {
   const [agentInput, setAgentInput] = useState('');
 
   async function chooseFolder() {
-    const fp = await window.cursovable.selectFolder();
+    const fp = await window.termiAI.selectFolder();
     if (fp) setFolder(fp);
   }
 
@@ -35,7 +35,7 @@ function LegacyApp() {
     if (!folder) return alert('Select a folder first');
     setIsStarting(true);
     try {
-      const { url } = await window.cursovable.startVite({ folderPath: folder, manager });
+      const { url } = await window.termiAI.startVite({ folderPath: folder, manager });
       setPreviewUrl(url);
     } catch (e) {
       alert(e.message || String(e));
@@ -45,14 +45,14 @@ function LegacyApp() {
   }
 
   async function stopPreview() {
-    await window.cursovable.stopVite();
+    await window.termiAI.stopVite();
     setPreviewUrl(null);
   }
 
   async function toggleDebugMode() {
     try {
       const newDebugMode = !debugMode;
-      const { ok } = await window.cursovable.setDebugMode({ 
+      const { ok } = await window.termiAI.setDebugMode({ 
         enabled: newDebugMode,
         options: {
           mockTypingDelay: 100,
@@ -71,19 +71,19 @@ function LegacyApp() {
 
   // Subscribe to Vite and cursor-agent logs
   useEffect(() => {
-    const unsubV = window.cursovable.onViteLog((payload) => {
+    const unsubV = window.termiAI.onViteLog((payload) => {
       setViteLogs((prev) => {
         const next = [...prev, payload];
         return next.length > 1000 ? next.slice(-1000) : next;
       });
     });
-    const unsubC = window.cursovable.onCursorLog((payload) => {
+    const unsubC = window.termiAI.onCursorLog((payload) => {
       setCursorLogs((prev) => {
         const next = [...prev, payload];
         return next.length > 1000 ? next.slice(-1000) : next;
       });
     });
-    const unsubF = window.cursovable.folderSelected((folderPath) => {
+    const unsubF = window.termiAI.folderSelected((folderPath) => {
       setFolder(folderPath);
     });
     return () => { 
@@ -97,7 +97,7 @@ function LegacyApp() {
   useEffect(() => {
     async function checkDebugMode() {
       try {
-        const { debugMode: currentDebugMode } = await window.cursovable.getDebugMode();
+        const { debugMode: currentDebugMode } = await window.termiAI.getDebugMode();
         setDebugMode(currentDebugMode);
       } catch (err) {
         console.warn('Failed to get debug mode status:', err);
@@ -136,7 +136,7 @@ function LegacyApp() {
   useEffect(() => {
     const checkStatus = async () => {
       try {
-        const status = await window.cursovable.getTerminalStatus();
+        const status = await window.termiAI.getTerminalStatus();
         const statusEl = document.getElementById('terminal-status');
         if (statusEl) {
           statusEl.textContent = `${status.terminalType} (PTY: ${status.hasPty ? 'Yes' : 'No'})`;
@@ -245,7 +245,7 @@ function LegacyApp() {
                           const runId = last?.runId;
                           console.log('Sending input, runId:', runId, 'input:', agentInput);
                           // Always send input - persistent terminal will handle it if no agent running
-                          await window.cursovable.sendCursorInput({ runId, data: agentInput + '\n' });
+                          await window.termiAI.sendCursorInput({ runId, data: agentInput + '\n' });
                           setAgentInput('');
                         }
                         if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'c') {
@@ -253,7 +253,7 @@ function LegacyApp() {
                           const runId = last?.runId;
                           console.log('Sending SIGINT, runId:', runId);
                           // Always send signal - persistent terminal will handle it if no agent running
-                          await window.cursovable.sendCursorSignal({ runId, signal: 'SIGINT' });
+                          await window.termiAI.sendCursorSignal({ runId, signal: 'SIGINT' });
                         }
                       }}
                     />
@@ -262,7 +262,7 @@ function LegacyApp() {
                       const runId = last?.runId;
                       console.log('Send button clicked, runId:', runId, 'input:', agentInput);
                       // Always send input - persistent terminal will handle it if no agent running
-                      await window.cursovable.sendCursorInput({ runId, data: agentInput + '\n' });
+                      await window.termiAI.sendCursorInput({ runId, data: agentInput + '\n' });
                       setAgentInput('');
                     }}>Send</button>
                     <button className="secondary" onClick={async () => {
@@ -270,18 +270,18 @@ function LegacyApp() {
                       const runId = last?.runId;
                       console.log('Ctrl+C button clicked, runId:', runId);
                       // Always send signal - persistent terminal will handle it if no agent running
-                      await window.cursovable.sendCursorSignal({ runId, signal: 'SIGINT' });
+                      await window.termiAI.sendCursorSignal({ runId, signal: 'SIGINT' });
                     }}>Ctrl+C</button>
                     <button className="secondary" onClick={async () => {
                       console.log('Starting persistent terminal...');
                       try {
                         // Send a dummy input to trigger persistent terminal creation
-                        const result = await window.cursovable.sendCursorInput({ runId: null, data: '\n' });
+                        const result = await window.termiAI.sendCursorInput({ runId: null, data: '\n' });
                         console.log('Terminal start result:', result);
                         
                         // Wait a moment and check status
                         setTimeout(async () => {
-                          const status = await window.cursovable.getTerminalStatus();
+                          const status = await window.termiAI.getTerminalStatus();
                           console.log('Terminal status after start:', status);
                         }, 500);
                       } catch (err) {
@@ -308,7 +308,7 @@ function LegacyApp() {
           <span style={{ flex: 1, padding: '8px', color: '#6b7280', fontSize: '12px' }}>
             Legacy chat interface - Use projects for session management
           </span>
-          <button className="secondary" onClick={async () => { await window.cursovable.clearHistory(); location.reload(); }}>Clear</button>
+          <button className="secondary" onClick={async () => { await window.termiAI.clearHistory(); location.reload(); }}>Clear</button>
         </div>
         {/* Chat panel retained for legacy layout; new ProjectView uses its own */}
         <ProjectView projectId={null} onBack={() => {}} />

--- a/renderer/src/components/Chat.jsx
+++ b/renderer/src/components/Chat.jsx
@@ -80,7 +80,7 @@ export default function Chat({ cwd, projectId, onPlayMiniGame, onCloseMiniGame, 
       : messages;
 
     // Model selection (empty string means default/auto; don't send to CLI)
-    const modelStorageKey = `cursovable-model-${projectId || 'legacy'}`;
+    const modelStorageKey = `termi-ai-model-${projectId || 'legacy'}`;
     const suggestedModels = [
       'gpt-5',
       'gpt-5-fast',
@@ -237,7 +237,7 @@ export default function Chat({ cwd, projectId, onPlayMiniGame, onCloseMiniGame, 
     // Check terminal status on mount and when current session's busy state changes
     const checkTerminalStatus = useCallback(async () => {
       try {
-        const status = await window.cursovable.getTerminalStatus();
+        const status = await window.termiAI.getTerminalStatus();
         setTerminalStatus(status);
         
         // Add status message if there are issues

--- a/renderer/src/components/Chat/ActionLog.jsx
+++ b/renderer/src/components/Chat/ActionLog.jsx
@@ -187,15 +187,15 @@ export default function ActionLog({ toolCalls, isVisible = false, onToggle, isEx
                         const { defaultEditor } = require('../../store/settings');
                       } catch {}
                       try {
-                        const settings = JSON.parse(localStorage.getItem('cursovable-settings') || '{}');
+                        const settings = JSON.parse(localStorage.getItem('termi-ai-settings') || '{}');
                         const editor = settings.defaultEditor || '';
                         if (editor) {
-                          window.cursovable.openInEditor({ folderPath: cwd || '', editor, targetPath: fullPath });
+                          window.termiAI.openInEditor({ folderPath: cwd || '', editor, targetPath: fullPath });
                         } else {
-                          window.cursovable.openFolder(fullPath);
+                          window.termiAI.openFolder(fullPath);
                         }
                       } catch {
-                        try { window.cursovable.openFolder(fullPath); } catch {}
+                        try { window.termiAI.openFolder(fullPath); } catch {}
                       }
                     }}
                     onKeyDown={(e) => {
@@ -203,15 +203,15 @@ export default function ActionLog({ toolCalls, isVisible = false, onToggle, isEx
                         e.preventDefault();
                         e.stopPropagation();
                         try {
-                          const settings = JSON.parse(localStorage.getItem('cursovable-settings') || '{}');
+                          const settings = JSON.parse(localStorage.getItem('termi-ai-settings') || '{}');
                           const editor = settings.defaultEditor || '';
                           if (editor) {
-                            window.cursovable.openInEditor({ folderPath: cwd || '', editor, targetPath: fullPath });
+                            window.termiAI.openInEditor({ folderPath: cwd || '', editor, targetPath: fullPath });
                           } else {
-                            window.cursovable.openFolder(fullPath);
+                            window.termiAI.openFolder(fullPath);
                           }
                         } catch {
-                          try { window.cursovable.openFolder(fullPath); } catch {}
+                          try { window.termiAI.openFolder(fullPath); } catch {}
                         }
                       }
                     }}

--- a/renderer/src/components/Chat/Header.jsx
+++ b/renderer/src/components/Chat/Header.jsx
@@ -205,8 +205,8 @@ export default function Header({
           <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
             <button
               onClick={() => {
-                if (window.cursovableLogRouter) {
-                  window.cursovableLogRouter.debugState();
+                if (window.termiAILogRouter) {
+                  window.termiAILogRouter.debugState();
                 }
               }}
               style={{
@@ -223,8 +223,8 @@ export default function Header({
             </button>
             <button
               onClick={() => {
-                if (window.cursovableLogRouter) {
-                  window.cursovableLogRouter.debugSessions();
+                if (window.termiAILogRouter) {
+                  window.termiAILogRouter.debugSessions();
                 }
               }}
               style={{

--- a/renderer/src/components/Chat/hooks/chatUtils.js
+++ b/renderer/src/components/Chat/hooks/chatUtils.js
@@ -73,7 +73,7 @@ export const generateRunId = () => `${Date.now()}-${Math.random().toString(36).s
 export const verifyAndSwitchWorkingDirectory = async (desiredCwd) => {
   const normalizePath = (p) => (p || '').replace(/\\/g, '/').replace(/\/+$/,'');
   const desired = normalizePath(desiredCwd);
-  let currentWd = normalizePath(await window.cursovable.getWorkingDirectory());
+  let currentWd = normalizePath(await window.termiAI.getWorkingDirectory());
   
   if (!currentWd || currentWd !== desired) {
     const proceed = confirm(
@@ -81,8 +81,8 @@ export const verifyAndSwitchWorkingDirectory = async (desiredCwd) => {
     );
     if (!proceed) return false;
     
-    await window.cursovable.setWorkingDirectory(desired);
-    currentWd = normalizePath(await window.cursovable.getWorkingDirectory());
+    await window.termiAI.setWorkingDirectory(desired);
+    currentWd = normalizePath(await window.termiAI.getWorkingDirectory());
     if (currentWd !== desired) {
       alert('Failed to switch working directory to the project folder. Aborting to keep your environment safe.');
       return false;

--- a/renderer/src/components/Chat/hooks/errorHandling.js
+++ b/renderer/src/components/Chat/hooks/errorHandling.js
@@ -142,8 +142,8 @@ export const validateInput = ({ text, cwd, busy }) => {
  */
 export const logCursorDebugInfo = async ({ runId, cwd }) => {
   try {
-    const currentWd = await window.cursovable.getWorkingDirectory();
-    await window.cursovable.cursorDebugLog({ 
+    const currentWd = await window.termiAI.getWorkingDirectory();
+    await window.termiAI.cursorDebugLog({ 
       line: `[cursor-agent] Working directory: ${currentWd || '(none)'}`, 
       runId 
     });

--- a/renderer/src/components/Chat/hooks/messageHandlers.js
+++ b/renderer/src/components/Chat/hooks/messageHandlers.js
@@ -104,7 +104,7 @@ export const handleJsonLogLine = async (parsed, {
       
       // Get the session object from the log router (passed from the runner)
       // This tells us exactly which session started this terminal
-      const sessionObject = window.cursovableLogRouter?.getCurrentRunSession?.(runId);
+      const sessionObject = window.termiAILogRouter?.getCurrentRunSession?.(runId);
       
       if (sessionObject) {
         console.log(`🆔 Found session object from runner:`, sessionObject);
@@ -458,7 +458,7 @@ export const createLogStreamHandler = ({
           console.log(`🚀 Using ${getCurrentSessions ? 'fresh' : 'stale'} session state:`, currentSessions.map(s => ({ id: s.id, name: s.name, cursorSessionId: s.cursorSessionId })));
           
           // Get the session ID from the log router for this run
-          const sessionObject = window.cursovableLogRouter?.getCurrentRunSession?.(runId);
+          const sessionObject = window.termiAILogRouter?.getCurrentRunSession?.(runId);
           const internalSessionId = sessionObject?.id;
           
           const isComplete = await handleJsonLogLine(parsed, {
@@ -491,7 +491,7 @@ export const createLogStreamHandler = ({
       
       for (const line of lines) {
         // Get the session ID from the log router for this run
-        const sessionObject = window.cursovableLogRouter?.getCurrentRunSession?.(runId);
+        const sessionObject = window.termiAILogRouter?.getCurrentRunSession?.(runId);
         const internalSessionId = sessionObject?.id;
         
         const isComplete = await handleStreamLogLine(line, {

--- a/renderer/src/components/Chat/hooks/useSessionManager.js
+++ b/renderer/src/components/Chat/hooks/useSessionManager.js
@@ -27,7 +27,7 @@ export const useSessionManager = (projectId) => {
   
   const loadSessions = useCallback(() => {
     try {
-      const storedSessions = localStorage.getItem(`cursovable-sessions-${projectId || 'legacy'}`);
+      const storedSessions = localStorage.getItem(`termi-ai-sessions-${projectId || 'legacy'}`);
       if (storedSessions) {
         const parsedSessions = JSON.parse(storedSessions);
         console.log(`🔍 loadSessions: Loaded ${parsedSessions.length} sessions from localStorage:`, 
@@ -42,7 +42,7 @@ export const useSessionManager = (projectId) => {
 
   const saveSessions = useCallback((sessionsToSave) => {
     try {
-      localStorage.setItem(`cursovable-sessions-${projectId || 'legacy'}`, JSON.stringify(sessionsToSave));
+      localStorage.setItem(`termi-ai-sessions-${projectId || 'legacy'}`, JSON.stringify(sessionsToSave));
     } catch (error) {
       console.warn('Failed to save sessions to localStorage:', error);
     }
@@ -476,8 +476,8 @@ export const useSessionManager = (projectId) => {
     console.log('🔍 SessionProvider received cursor log:', payload);
     
     // Route the log to the appropriate handler based on runId
-    if (window.cursovableLogRouter) {
-      window.cursovableLogRouter.routeLog(payload);
+    if (window.termiAILogRouter) {
+      window.termiAILogRouter.routeLog(payload);
     }
     
     // Handle terminal logs for display
@@ -603,9 +603,9 @@ export const useSessionManager = (projectId) => {
       };
       
       // Register the session object in the log router
-      if (window.cursovableLogRouter) {
+      if (window.termiAILogRouter) {
         const messageHandler = createMessageHandler(runId, sessionId);
-        window.cursovableLogRouter.registerHandler(runId, messageHandler, sessionObject);
+        window.termiAILogRouter.registerHandler(runId, messageHandler, sessionObject);
       }
       
       // Get project information and settings
@@ -613,10 +613,10 @@ export const useSessionManager = (projectId) => {
       const settings = loadSettings();
       
       // Call the cursor-agent CLI
-      const result = await window.cursovable.runCursor({
+      const result = await window.termiAI.runCursor({
         message: text,
         sessionObject,
-        cwd: project?.path || await window.cursovable.getWorkingDirectory(),
+        cwd: project?.path || await window.termiAI.getWorkingDirectory(),
         apiKey: settings.apiKey || undefined,
         // No timeout - cursor-agent can run for hours depending on complexity
         model: settings.defaultModel || undefined, // Use default model from settings
@@ -653,8 +653,8 @@ export const useSessionManager = (projectId) => {
       setSessionBusy(sessionId, false);
       
       // Clean up the handler after completion
-      if (window.cursovableLogRouter) {
-        window.cursovableLogRouter.unregisterHandler(runId);
+      if (window.termiAILogRouter) {
+        window.termiAILogRouter.unregisterHandler(runId);
       }
     }
   }, [sessions, saveSessions, setSessionBusy, updateSessionWithCursorId, clearSessionTerminalLogs]);
@@ -747,15 +747,15 @@ export const useSessionManager = (projectId) => {
     
     // Check if we have a project prompt in localStorage (set by Dashboard)
     try {
-      const projectPrompt = localStorage.getItem(`cursovable-new-project-${projectId}`);
-      const projectTemplate = localStorage.getItem(`cursovable-new-project-template-${projectId}`);
+      const projectPrompt = localStorage.getItem(`termi-ai-new-project-${projectId}`);
+      const projectTemplate = localStorage.getItem(`termi-ai-new-project-template-${projectId}`);
       
       console.log(`🔍 Checking for new project auto-start:`, {
         projectId,
         hasExistingSessions: existingSessions.length > 0,
         projectPrompt,
         projectTemplate,
-        localStorageKeys: Object.keys(localStorage).filter(key => key.includes('cursovable-new-project'))
+        localStorageKeys: Object.keys(localStorage).filter(key => key.includes('termi-ai-new-project'))
       });
       
       if (projectPrompt) {
@@ -869,8 +869,8 @@ export const useSessionManager = (projectId) => {
         createNewProjectSession(newProjectInfo.prompt, newProjectInfo.template).then(() => {
           // Clean up the localStorage after starting
           try {
-            localStorage.removeItem(`cursovable-new-project-${projectId}`);
-            localStorage.removeItem(`cursovable-new-project-template-${projectId}`);
+            localStorage.removeItem(`termi-ai-new-project-${projectId}`);
+            localStorage.removeItem(`termi-ai-new-project-template-${projectId}`);
           } catch (e) {
             console.warn('Failed to cleanup new project localStorage:', e);
           }
@@ -910,9 +910,9 @@ export const useSessionManager = (projectId) => {
   
   // Set up the centralized log router
   const setupLogRouter = useCallback(() => {
-    // Only set up if window.cursovable is available (Electron environment)
-    if (!window.cursovable?.onCursorLog) {
-      console.log('window.cursovable.onCursorLog not available, skipping log router setup');
+    // Only set up if window.termiAI is available (Electron environment)
+    if (!window.termiAI?.onCursorLog) {
+      console.log('window.termiAI.onCursorLog not available, skipping log router setup');
       return null;
     }
 
@@ -980,15 +980,15 @@ export const useSessionManager = (projectId) => {
     };
 
     // Store the router globally
-    window.cursovableLogRouter = logRouter;
+    window.termiAILogRouter = logRouter;
     return logRouter;
   }, [sessions, currentSessionId]);
 
   // Clean up the log router
   const cleanupLogRouter = useCallback(() => {
-    if (window.cursovableLogRouter) {
-      window.cursovableLogRouter.handlers.clear();
-      delete window.cursovableLogRouter;
+    if (window.termiAILogRouter) {
+      window.termiAILogRouter.handlers.clear();
+      delete window.termiAILogRouter;
     }
   }, []);
 
@@ -1129,8 +1129,8 @@ export const useSessionManager = (projectId) => {
       
       // Store test project info in localStorage
       const testProjectId = 'test-project-' + Date.now();
-      localStorage.setItem(`cursovable-new-project-${testProjectId}`, testPrompt);
-      localStorage.setItem(`cursovable-new-project-template-${testProjectId}`, testTemplate);
+      localStorage.setItem(`termi-ai-new-project-${testProjectId}`, testPrompt);
+      localStorage.setItem(`termi-ai-new-project-template-${testProjectId}`, testTemplate);
       
       console.log(`🧪 Stored test project info for: ${testProjectId}`);
       

--- a/renderer/src/components/Chat/hooks/useTerminalStatus.js
+++ b/renderer/src/components/Chat/hooks/useTerminalStatus.js
@@ -5,9 +5,9 @@ export const useTerminalStatus = (sessions, currentSessionId, updateSessionWithC
 
   // Set up the centralized log router for terminal communication
   const setupLogRouter = useCallback(() => {
-    // Only set up if window.cursovable is available (Electron environment)
-    if (!window.cursovable?.onCursorLog) {
-      console.log('window.cursovable.onCursorLog not available, skipping log router setup');
+    // Only set up if window.termiAI is available (Electron environment)
+    if (!window.termiAI?.onCursorLog) {
+      console.log('window.termiAI.onCursorLog not available, skipping log router setup');
       return null;
     }
 
@@ -70,7 +70,7 @@ export const useTerminalStatus = (sessions, currentSessionId, updateSessionWithC
     };
 
     // Store the router globally and in our ref
-    window.cursovableLogRouter = logRouter;
+    window.termiAILogRouter = logRouter;
     logRouterRef.current = logRouter;
 
     return logRouter;
@@ -136,8 +136,8 @@ export const useTerminalStatus = (sessions, currentSessionId, updateSessionWithC
       logRouterRef.current.handlers.clear();
       logRouterRef.current = null;
     }
-    if (window.cursovableLogRouter) {
-      delete window.cursovableLogRouter;
+    if (window.termiAILogRouter) {
+      delete window.termiAILogRouter;
     }
   }, []);
 

--- a/renderer/src/components/CommitModal.jsx
+++ b/renderer/src/components/CommitModal.jsx
@@ -47,7 +47,7 @@ function CommitModal({
     setCommitOnCurrent(true);
     
     try {
-      const res = await window.cursovable.getGitBranches({ folderPath: folder });
+      const res = await window.termiAI.getGitBranches({ folderPath: folder });
       if (!res || res.ok === false) {
         setBranches([]);
         setCurrentBranch('');
@@ -70,7 +70,7 @@ function CommitModal({
     }
     
     try {
-      const reflogRes = await window.cursovable.getReflog({ folderPath: folder, limit: 50 });
+      const reflogRes = await window.termiAI.getReflog({ folderPath: folder, limit: 50 });
       if (reflogRes && reflogRes.ok) setReflogEntries(reflogRes.entries || []);
       else setReflogEntries([]);
     } catch { 
@@ -103,7 +103,7 @@ function CommitModal({
     setCommitError('');
     
     try {
-      const res = await window.cursovable.gitCommit({ 
+      const res = await window.termiAI.gitCommit({ 
         folderPath: folder, 
         message, 
         ...(mode ? { mode } : {}), 
@@ -136,7 +136,7 @@ function CommitModal({
     setRestoreError('');
     
     try {
-      const res = await window.cursovable.restoreLocalCommit({ 
+      const res = await window.termiAI.restoreLocalCommit({ 
         folderPath: folder, 
         action: 'reset-hard', 
         sha: sha 
@@ -155,7 +155,7 @@ function CommitModal({
 
   async function refreshReflog() {
     try {
-      const r = await window.cursovable.getReflog({ folderPath: folder, limit: 50 });
+      const r = await window.termiAI.getReflog({ folderPath: folder, limit: 50 });
       if (r && r.ok) setReflogEntries(r.entries || []);
     } catch {}
   }

--- a/renderer/src/components/Modals/CreateTemplateModal.jsx
+++ b/renderer/src/components/Modals/CreateTemplateModal.jsx
@@ -16,7 +16,7 @@ function CreateTemplateModal({ onClose, onCreate, initialTemplate = 'react-vite'
   const [fixingPermissions, setFixingPermissions] = useState(false);
 
   async function browseParent() {
-    const fp = await window.cursovable.selectFolder();
+    const fp = await window.termiAI.selectFolder();
     if (fp) {
       setParentDir(fp);
       setPermissionStatus(null); // Reset permission status when folder changes
@@ -29,7 +29,7 @@ function CreateTemplateModal({ onClose, onCreate, initialTemplate = 'react-vite'
     try {
       setCheckingPermissions(true);
       setError('');
-      const result = await window.cursovable.checkDirectoryPermissions({ directoryPath: parentDir });
+      const result = await window.termiAI.checkDirectoryPermissions({ directoryPath: parentDir });
       setPermissionStatus(result);
     } catch (err) {
       setError(`Failed to check permissions: ${err.message}`);
@@ -44,7 +44,7 @@ function CreateTemplateModal({ onClose, onCreate, initialTemplate = 'react-vite'
     try {
       setFixingPermissions(true);
       setError('');
-      const result = await window.cursovable.fixDirectoryPermissions({ directoryPath: parentDir });
+      const result = await window.termiAI.fixDirectoryPermissions({ directoryPath: parentDir });
       if (result.ok) {
         // Re-check permissions after fixing
         await checkPermissions();
@@ -71,7 +71,7 @@ function CreateTemplateModal({ onClose, onCreate, initialTemplate = 'react-vite'
       if (!parentDir || !projectName.trim()) throw new Error('Choose folder and enter project name');
       
       // Check permissions before creating project
-      const permCheck = await window.cursovable.checkDirectoryPermissions({ directoryPath: parentDir });
+      const permCheck = await window.termiAI.checkDirectoryPermissions({ directoryPath: parentDir });
       if (!permCheck.ok) {
         throw new Error(`Permission check failed: ${permCheck.error}`);
       }
@@ -80,13 +80,13 @@ function CreateTemplateModal({ onClose, onCreate, initialTemplate = 'react-vite'
         throw new Error(`Insufficient permissions in selected folder. The folder needs read/write access for cursor-agent to work properly. Current permissions: ${permCheck.permissions.mode}`);
       }
       
-      const res = await window.cursovable.createProjectScaffold({ parentDir, projectName: projectName.trim(), template, prompt });
+      const res = await window.termiAI.createProjectScaffold({ parentDir, projectName: projectName.trim(), template, prompt });
       if (!res || !res.ok) throw new Error(res?.error || 'Failed to create project');
       
       const projectPath = res.path;
       
       // Verify the created project has proper permissions
-      const projectPermCheck = await window.cursovable.checkDirectoryPermissions({ directoryPath: projectPath });
+      const projectPermCheck = await window.termiAI.checkDirectoryPermissions({ directoryPath: projectPath });
       if (!projectPermCheck.ok || !projectPermCheck.permissions.createFiles) {
         throw new Error(`Project created but cursor-agent may not have sufficient permissions to work in: ${projectPath}. Please check folder permissions.`);
       }

--- a/renderer/src/components/Modals/LoadProjectModal.jsx
+++ b/renderer/src/components/Modals/LoadProjectModal.jsx
@@ -33,7 +33,7 @@ function LoadProjectModal({ onClose, onLoad }) {
     setDetectError('');
     setDetecting(true);
     try {
-      const res = await window.cursovable.detectProject(fp);
+      const res = await window.termiAI.detectProject(fp);
       if (!res || !res.ok) {
         throw new Error(res?.error || 'Failed to detect project');
       }
@@ -71,7 +71,7 @@ function LoadProjectModal({ onClose, onLoad }) {
   }
 
   async function pickFolder() {
-    const fp = await window.cursovable.selectFolder();
+    const fp = await window.termiAI.selectFolder();
     if (fp) await detectAndPrefill(fp);
   }
 

--- a/renderer/src/components/Modals/SettingsModal.jsx
+++ b/renderer/src/components/Modals/SettingsModal.jsx
@@ -31,7 +31,7 @@ function SettingsModal({ initial, onClose, onSave }) {
     let mounted = true;
     (async () => {
       try {
-        const list = await window.cursovable.detectEditors();
+        const list = await window.termiAI.detectEditors();
         if (mounted && Array.isArray(list)) setAvailableEditors(list);
       } catch {
         if (mounted) setAvailableEditors([]);

--- a/renderer/src/components/ProjectHeader.jsx
+++ b/renderer/src/components/ProjectHeader.jsx
@@ -180,7 +180,7 @@ function ProjectHeader({
                 disabled={!folder || !selectedEditor}
                 onClick={async () => { 
                   if (folder && selectedEditor) {
-                    await window.cursovable.openInEditor({ folderPath: folder, editor: selectedEditor });
+                    await window.termiAI.openInEditor({ folderPath: folder, editor: selectedEditor });
                     // Close menu after action
                     closeMenu();
                   }
@@ -228,7 +228,7 @@ function ProjectHeader({
                     // If URL parsing fails, use original URL
                     urlToOpen = previewUrl;
                   }
-                  await window.cursovable.openExternal(urlToOpen);
+                  await window.termiAI.openExternal(urlToOpen);
                   // Close menu after action
                   closeMenu();
                 }
@@ -253,7 +253,7 @@ function ProjectHeader({
               onMouseEnter={(e) => e.target.style.background = '#1a2331'}
               onMouseLeave={(e) => e.target.style.background = 'transparent'}
               onClick={async () => { 
-                if (folder) await window.cursovable.openFolder(folder); 
+                if (folder) await window.termiAI.openFolder(folder); 
                 // Close menu after action
                 closeMenu();
               }}

--- a/renderer/src/components/SessionTerminals.jsx
+++ b/renderer/src/components/SessionTerminals.jsx
@@ -357,8 +357,8 @@ export default function SessionTerminals() {
                 <button
                   onClick={() => {
                     // Debug button to show log router state
-                    if (window.cursovableLogRouter) {
-                      window.cursovableLogRouter.debugState();
+                    if (window.termiAILogRouter) {
+                      window.termiAILogRouter.debugState();
                     } else {
                       console.log('🔧 Log router not available');
                     }
@@ -378,8 +378,8 @@ export default function SessionTerminals() {
                 <button
                   onClick={() => {
                     // Debug button to show session state
-                    if (window.cursovableLogRouter) {
-                      window.cursovableLogRouter.debugSessions();
+                    if (window.termiAILogRouter) {
+                      window.termiAILogRouter.debugSessions();
                     } else {
                       console.log('🔧 Log router not available');
                     }

--- a/renderer/src/pages/Dashboard.jsx
+++ b/renderer/src/pages/Dashboard.jsx
@@ -45,8 +45,8 @@ export default function Dashboard({ onOpenProject }) {
       const projectPrompt = idea || 'Create a starter app';
       const projectTemplate = template;
       
-      localStorage.setItem(`cursovable-new-project-${project.id}`, projectPrompt);
-      localStorage.setItem(`cursovable-new-project-template-${project.id}`, projectTemplate);
+      localStorage.setItem(`termi-ai-new-project-${project.id}`, projectPrompt);
+      localStorage.setItem(`termi-ai-new-project-template-${project.id}`, projectTemplate);
       
       console.log(`🚀 Stored new project info for auto-start:`, {
         projectId: project.id,

--- a/renderer/src/pages/ProjectView.jsx
+++ b/renderer/src/pages/ProjectView.jsx
@@ -284,7 +284,7 @@ function ProjectViewInner({ projectId, onBack }) {
         setIsInstalling(true);
         try {
           const { packageManager } = loadSettings();
-          const res = await window.cursovable.installPackages({ folderPath: folder, manager: packageManager || 'yarn' });
+          const res = await window.termiAI.installPackages({ folderPath: folder, manager: packageManager || 'yarn' });
           if (!res || !res.ok) {
             console.warn('Dependency install failed or returned error:', res?.error);
           }
@@ -298,10 +298,10 @@ function ProjectViewInner({ projectId, onBack }) {
       setIsStarting(true);
       let urlObj;
       if (projectType === 'html') {
-        urlObj = await window.cursovable.startHtml({ folderPath: folder });
+        urlObj = await window.termiAI.startHtml({ folderPath: folder });
       } else {
         const { packageManager } = loadSettings();
-        urlObj = await window.cursovable.startVite({ folderPath: folder, manager: packageManager || 'yarn' });
+        urlObj = await window.termiAI.startVite({ folderPath: folder, manager: packageManager || 'yarn' });
       }
       const { url } = urlObj;
       setPreviewUrl(url);
@@ -314,9 +314,9 @@ function ProjectViewInner({ projectId, onBack }) {
 
   async function stopPreview() {
     if (projectType === 'html') {
-      await window.cursovable.stopHtml();
+      await window.termiAI.stopHtml();
     } else {
-      await window.cursovable.stopVite();
+      await window.termiAI.stopVite();
     }
     setPreviewUrl(null);
   }
@@ -351,7 +351,7 @@ function ProjectViewInner({ projectId, onBack }) {
     (async () => {
       try {
         if (!folder) return;
-        const res = await window.cursovable.getProjectRoutes({ folderPath: folder, projectType });
+        const res = await window.termiAI.getProjectRoutes({ folderPath: folder, projectType });
         if (res && res.ok && Array.isArray(res.routes)) {
           setRoutes(res.routes);
         } else {
@@ -367,7 +367,7 @@ function ProjectViewInner({ projectId, onBack }) {
   useEffect(() => {
     (async () => {
       try {
-        const list = await window.cursovable.detectEditors();
+        const list = await window.termiAI.detectEditors();
         if (Array.isArray(list)) setEditors(list);
       } catch {}
     })();
@@ -440,10 +440,10 @@ function ProjectViewInner({ projectId, onBack }) {
 
   // Subscribe to preview and cursor logs (buffered to reduce re-renders)
   useEffect(() => {
-    const unsubV = window.cursovable.onViteLog((payload) => {
+    const unsubV = window.termiAI.onViteLog((payload) => {
       appendSanitizedLogsBuffered(viteBufferRef, payload);
     });
-    const unsubC = window.cursovable.onCursorLog((payload) => {
+    const unsubC = window.termiAI.onCursorLog((payload) => {
       appendSanitizedLogsBuffered(cursorBufferRef, payload);
       appendRawLogsBuffered(rawCursorBufferRef, payload);
     });
@@ -458,14 +458,14 @@ function ProjectViewInner({ projectId, onBack }) {
     let started = false;
     const onPerf = (payload) => setPerfStats(payload);
     try {
-      if (window.cursovable && window.cursovable.onPerfStats) {
-        unsub = window.cursovable.onPerfStats(onPerf);
+      if (window.termiAI && window.termiAI.onPerfStats) {
+        unsub = window.termiAI.onPerfStats(onPerf);
       }
     } catch {}
-    (async () => { try { if (window.cursovable && window.cursovable.startPerf) { await window.cursovable.startPerf(); started = true; } } catch {} })();
+    (async () => { try { if (window.termiAI && window.termiAI.startPerf) { await window.termiAI.startPerf(); started = true; } } catch {} })();
     return () => {
       try { unsub && unsub(); } catch {}
-      try { if (started && window.cursovable && window.cursovable.stopPerf) window.cursovable.stopPerf(); } catch {}
+      try { if (started && window.termiAI && window.termiAI.stopPerf) window.termiAI.stopPerf(); } catch {}
     };
   }, []);
 
@@ -495,7 +495,7 @@ function ProjectViewInner({ projectId, onBack }) {
     let mounted = true;
     const checkStatus = async () => {
       try {
-        const status = await window.cursovable.getTerminalStatus();
+        const status = await window.termiAI.getTerminalStatus();
         if (!mounted) return;
         const text = `${status.terminalType} (PTY: ${status.hasPty ? 'Yes' : 'No'})`;
         setTerminalStatusText(text);

--- a/renderer/src/providers/AuthProvider.jsx
+++ b/renderer/src/providers/AuthProvider.jsx
@@ -36,7 +36,7 @@ export default function AuthProvider({ children }) {
         setShowLogin(false);
         return true;
       }
-      const status = await window.cursovable.getCursorAuthStatus?.();
+      const status = await window.termiAI.getCursorAuthStatus?.();
       const isIn = !!(status && status.loggedIn);
       setLoggedIn(isIn);
       if (!isIn) setShowLogin(true);
@@ -60,7 +60,7 @@ export default function AuthProvider({ children }) {
         setShowLogin(false);
         return;
       }
-      await window.cursovable.triggerCursorAuthLogin?.();
+      await window.termiAI.triggerCursorAuthLogin?.();
       const isIn = await refreshStatus();
       if (isIn) setShowLogin(false);
     } catch {}
@@ -82,18 +82,18 @@ export default function AuthProvider({ children }) {
 
   // Subscribe to auth link/log streams
   useEffect(() => {
-    const unsubLog = window.cursovable.onCursorAuthLog?.((payload) => {
+    const unsubLog = window.termiAI.onCursorAuthLog?.((payload) => {
       setAuthLogs((prev) => {
         const next = [...prev, { ts: payload.ts || Date.now(), line: String(payload.line || '') }];
         return next.length > 500 ? next.slice(-500) : next;
       });
     });
-    const unsubLink = window.cursovable.onCursorAuthLink?.(async ({ url }) => {
+    const unsubLink = window.termiAI.onCursorAuthLink?.(async ({ url }) => {
       if (!url) return;
       setAuthLink(url);
       if (!openedRef.current) {
         openedRef.current = true;
-        try { await window.cursovable.openExternal(url); } catch {}
+        try { await window.termiAI.openExternal(url); } catch {}
       }
     });
     return () => { try { unsubLog && unsubLog(); } catch {} try { unsubLink && unsubLink(); } catch {} };
@@ -140,14 +140,14 @@ export default function AuthProvider({ children }) {
               </div>
             </div>
             <div style={{ fontSize: 12, color: '#9ca3af' }}>
-              Learn more in the <a href="#" onClick={async (e) => { e.preventDefault(); try { await window.cursovable.openExternal('https://docs.cursor.com/en/cli/overview'); } catch {} }} style={{ color: '#93c5fd', textDecoration: 'underline' }}>Cursor CLI docs</a>.
+              Learn more in the <a href="#" onClick={async (e) => { e.preventDefault(); try { await window.termiAI.openExternal('https://docs.cursor.com/en/cli/overview'); } catch {} }} style={{ color: '#93c5fd', textDecoration: 'underline' }}>Cursor CLI docs</a>.
             </div>
             {authLink && (
               <div style={{ fontSize: 12, background: '#0b0f16', border: '1px solid #27354a', borderRadius: 6, padding: 10 }}>
                 <div style={{ color: '#cde3ff', marginBottom: 6 }}>Authentication link</div>
                 <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
                   <Input value={authLink} readOnly />
-                  <Button className="compact" onClick={async () => { try { await window.cursovable.openExternal(authLink); } catch {} }}>Open</Button>
+                  <Button className="compact" onClick={async () => { try { await window.termiAI.openExternal(authLink); } catch {} }}>Open</Button>
                 </div>
                 {/* Spinner + Waiting text */}
                 <style>{`@keyframes auth-spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }`}</style>

--- a/renderer/src/providers/SessionProvider.jsx
+++ b/renderer/src/providers/SessionProvider.jsx
@@ -39,8 +39,8 @@ export const SessionProvider = ({ children, projectId }) => {
   // Set up the log router and cursor log handling
   useEffect(() => {  
     // Subscribe to the global log stream once
-    if (window.cursovable?.onCursorLog) {
-      const unsubscribe = window.cursovable.onCursorLog((payload) => {
+    if (window.termiAI?.onCursorLog) {
+      const unsubscribe = window.termiAI.onCursorLog((payload) => {
         
         // Handle cursor logs (terminal output, etc.)
         sessionManager.handleCursorLog(payload);
@@ -74,9 +74,9 @@ export const SessionProvider = ({ children, projectId }) => {
       return () => {
         if (unsubscribe) unsubscribe();
         // Clean up the global router
-        if (window.cursovableLogRouter) {
-          window.cursovableLogRouter.handlers.clear();
-          delete window.cursovableLogRouter;
+        if (window.termiAILogRouter) {
+          window.termiAILogRouter.handlers.clear();
+          delete window.termiAILogRouter;
         }
       };
     }

--- a/renderer/src/store/projects.js
+++ b/renderer/src/store/projects.js
@@ -1,6 +1,6 @@
 // Simple localStorage-backed project store
 
-const STORAGE_KEY = 'cursovable-projects';
+const STORAGE_KEY = 'termi-ai-projects';
 
 export function loadProjects() {
   try {

--- a/renderer/src/store/settings.js
+++ b/renderer/src/store/settings.js
@@ -1,6 +1,6 @@
 // Simple localStorage-backed app-wide settings
 
-const STORAGE_KEY = 'cursovable-settings';
+const STORAGE_KEY = 'termi-ai-settings';
 
 export function getDefaultSettings() {
   return {


### PR DESCRIPTION
This commit updates all UI-facing references from "cursovable" to "Termi AI" branding:

- Updated HTML page title to "Termi AI"
- Changed window API object from window.cursovable to window.termiAI
- Updated log router from cursovableLogRouter to termiAILogRouter
- Changed all localStorage keys from cursovable-* to termi-ai-*
  - termi-ai-settings (settings store)
  - termi-ai-projects (projects store)
  - termi-ai-sessions-* (session storage)
  - termi-ai-new-project-* (new project creation)
  - termi-ai-model-* (model preferences)
- Updated all window.cursovable API references across 24 files
- Rebuilt application to generate new bundled assets

Files modified:
- electron/main.cjs (menu actions)
- electron/preload.cjs (context bridge API)
- renderer/index.html (page title)
- 21 renderer source files (components, pages, hooks, stores)